### PR TITLE
Fix add job icon style

### DIFF
--- a/lib/companies_web/templates/company/card.html.eex
+++ b/lib/companies_web/templates/company/card.html.eex
@@ -52,7 +52,7 @@
     <% end %>
 
     <%= link to: Routes.job_path(@conn, :new, locale(@conn), company_id: @company.id) do %>
-      <span class="icon icon-purle" >
+      <span class="icon purple" >
         <i class="fas fa-plus" ></i>
       </span>
         <%= gettext("Add a job") %>


### PR DESCRIPTION
Resolve #519

before: 
<img width="407" alt="image" src="https://user-images.githubusercontent.com/1032291/58870175-59390100-86c8-11e9-8e93-45550cc4cfaf.png">

after: 
<img width="548" alt="image" src="https://user-images.githubusercontent.com/1032291/58870187-62c26900-86c8-11e9-8410-561f9be0e050.png">
