### PR TITLE
Improve diff of edits

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -71,7 +71,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   };
 
-  var $diff = document.querySelector(".box .diff");
+  var $diff = document.querySelector(".box .diff pre");
 
   if ($diff) {
     var tabLinks = document.querySelectorAll(".tabs a");
@@ -79,23 +79,23 @@ document.addEventListener("DOMContentLoaded", function() {
       tab.addEventListener("click", changeTab);
     });
 
-    var original = document.querySelector(".box .original").innerHTML,
-      changes = document.querySelector(".box .changes").innerHTML,
+    var original = document.querySelector(".box .original pre").innerHTML,
+      changes = document.querySelector(".box .changes pre").innerHTML,
       diff = jsDiff.diffChars(original, changes),
       fragment = document.createDocumentFragment();
 
     diff.forEach(function(part) {
-      var color;
+      var backgroundColor;
       if (part.added) {
-        color = "green";
+        backgroundColor = "#acf2bd"
       } else if (part.removed) {
-        color = "red";
+        backgroundColor = "#fdb8c0"
       } else {
-        color = "grey";
+        backgroundColor = "inherit"
       }
 
       var span = document.createElement("span");
-      span.style.color = color;
+      span.style.backgroundColor = backgroundColor;
       span.appendChild(document.createTextNode(part.value));
       fragment.appendChild(span);
     });

--- a/lib/companies_web/templates/admin/pending_change/index.html.eex
+++ b/lib/companies_web/templates/admin/pending_change/index.html.eex
@@ -11,25 +11,27 @@
       <h1 class="title is-3 fancy">
         Pending Changes
       </h1>
-      <table>
+      <table class="table">
         <thead>
           <tr>
+            <th></th>
             <th>Action</th>
             <th>Resource</th>
             <th>Note</th>
-            <th></th>
+            <th>Created</th>
           </tr>
         </thead>
         <%= for pending_change <- @pending_changes do %>
         <tr>
-          <td><%= pending_change.action %></td>
-          <td><%= pending_change.resource %></td>
-          <td><%= pending_change.note %></td>
           <td>
             <%= link to: Routes.pending_change_path(@conn, :show, locale(@conn), pending_change) do %>
               <i class="fas fa-eye"></i>
             <% end %>
           </td>
+          <td><%= pending_change.action %></td>
+          <td><%= pending_change.resource %></td>
+          <td><%= pending_change.note %></td>
+          <td><%= pending_change.inserted_at %></td>
         </tr>
         <% end %>
       </table>

--- a/lib/companies_web/templates/admin/pending_change/show.html.eex
+++ b/lib/companies_web/templates/admin/pending_change/show.html.eex
@@ -17,9 +17,9 @@
       </div>
 
       <div class="box">
-        <div class="diff"></div>
-        <div class="changes is-hidden"><%= to_json(@pending_change.changes) %></div>
-        <div class="original is-hidden"><%= to_json(@pending_change.original)%></div>
+        <div class="diff"><pre></pre></div>
+        <div class="changes is-hidden"><pre><%= to_json(@pending_change.changes) %></pre></div>
+        <div class="original is-hidden"><pre><%= to_json(@pending_change.original)%></pre></div>
       </div>
 
       <%= form_tag(Routes.pending_change_path(@conn, :update, locale(@conn), @pending_change.id), method: "PATCH") do %>

--- a/lib/companies_web/views/admin/pending_change_view.ex
+++ b/lib/companies_web/views/admin/pending_change_view.ex
@@ -2,6 +2,6 @@ defmodule CompaniesWeb.Admin.PendingChangeView do
   use CompaniesWeb, :view
 
   def to_json(map) do
-    Jason.encode!(map)
+    Jason.encode!(map, pretty: true)
   end
 end


### PR DESCRIPTION
This PR improves the edit diff view. See also https://github.com/beam-community/elixir-companies/issues/533

It adds a column in the pending changes overview to see when the changes were made.

It also improves the diff view, by pretty printing the JSON and outputting them in a `<pre>` tag. Furthermore it shows additions/removals by setting the backgroundColor of the edits much like how github does it. It's still fairly basic but I think it works better
<img width="681" alt="Screenshot 2019-10-10 at 20 33 48" src="https://user-images.githubusercontent.com/54566/66599273-1a99e280-eba3-11e9-9888-d9a25c14fbc6.png">
