### PR TITLE
Automatically assign reviewers to pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Order alphabetically.
+# Order is important. The last matching pattern takes the most precedence.
+
+# Default owners for everything in the repo.
+* @beam-community/team


### PR DESCRIPTION
This adds a `.github/CODEOWNERS` file to automatically assign reviewers to pull requests.