### PR TITLE
Add approved rejected changes overview

### DIFF
--- a/lib/companies/pending_changes.ex
+++ b/lib/companies/pending_changes.ex
@@ -8,12 +8,26 @@ defmodule Companies.PendingChanges do
   alias Companies.Repo
   alias Companies.Schema.{Company, Job, Industry, PendingChange}
 
-  def all do
-    query =
-      from p in PendingChange,
-        where: is_nil(p.approved)
+  @doc """
+  Returns the list of paginated changes.
 
-    Repo.all(query)
+  ## Examples
+
+  iex> all()
+  [%PendingChange{}, ...]
+
+  iex> all(%{"approved" => false})
+  [%PendingChange{}, ...]
+
+  iex> all(%{"approved" => true})
+  [%PendingChange{}, ...]
+  """
+  def all(params \\ %{}) do
+    page = Map.get(params, "page", "1")
+
+    PendingChange
+    |> predicates(params)
+    |> Repo.paginate(page: page)
   end
 
   def approve(change_id, false) do
@@ -133,6 +147,9 @@ defmodule Companies.PendingChanges do
   defp notification(error, _user) do
     error
   end
+
+  defp predicates(query, %{"approved" => approval}), do: query |> where([p], p.approved == ^approval)
+  defp predicates(query, _), do: query |> where([p], is_nil(p.approved))
 
   defp resource_module("company"), do: Company
   defp resource_module("industry"), do: Industry

--- a/lib/companies_web/controllers/admin/pending_change_controller.ex
+++ b/lib/companies_web/controllers/admin/pending_change_controller.ex
@@ -4,8 +4,10 @@ defmodule CompaniesWeb.Admin.PendingChangeController do
 
   alias Companies.PendingChanges
 
-  def index(conn, _params) do
-    render(conn, "index.html", pending_changes: pending_changes())
+  def index(conn, params) do
+    pending_changes = PendingChanges.all(params)
+
+    render(conn, "index.html", pending_changes: pending_changes)
   end
 
   def show(conn, %{"id" => change_id}) do
@@ -29,6 +31,4 @@ defmodule CompaniesWeb.Admin.PendingChangeController do
         |> redirect(to: Routes.pending_change_path(conn, :index, locale(conn)))
     end
   end
-
-  defp pending_changes, do: PendingChanges.all()
 end

--- a/lib/companies_web/helpers/site_helpers.ex
+++ b/lib/companies_web/helpers/site_helpers.ex
@@ -4,6 +4,7 @@ defmodule CompaniesWeb.SiteHelpers do
   import CompaniesWeb.Gettext
 
   def query_params(%{query_params: %{"type" => type}}), do: [type: type]
+  def query_params(%{query_params: %{"approved" => approved}}), do: [approved: approved]
   def query_params(_), do: []
 
   def maintainers, do: Map.get(site_data(), :maintainers)

--- a/lib/companies_web/router.ex
+++ b/lib/companies_web/router.ex
@@ -50,7 +50,7 @@ defmodule CompaniesWeb.Router do
     scope "/admin", Admin do
       pipe_through [:admin]
 
-      resources "/pending", PendingChangeController
+      resources "/changes", PendingChangeController
     end
   end
 

--- a/lib/companies_web/templates/admin/pending_change/index.html.eex
+++ b/lib/companies_web/templates/admin/pending_change/index.html.eex
@@ -6,10 +6,29 @@
 <% end %>
 
 <section class="section">
+<div class="navbar">
+  <div class="field is-grouped navbar-end">
+      <p class="control">
+        <%= link to: Routes.pending_change_path(@conn, :index, locale(@conn)), class: "navbar-item button" do %>
+          <span><%= gettext("Pending Changes") %></span>
+        <% end %>
+      </p>
+      <p class="control">
+        <%= link to: Routes.pending_change_path(@conn, :index, locale(@conn), approved: true), class: "navbar-item button" do %>
+          <span><%= gettext("Approved Changes") %></span>
+        <% end %>
+      </p>
+      <p class="control">
+        <%= link to: Routes.pending_change_path(@conn, :index, locale(@conn), approved: false), class: "navbar-item button" do %>
+          <span><%= gettext("Rejected Changes") %></span>
+        <% end %>
+      </p>
+  </div>
+  </div>
   <div class="container">
     <div class="content">
       <h1 class="title is-3 fancy">
-        Pending Changes
+        <%= pending_changes_title(@conn) %>
       </h1>
       <table class="table">
         <thead>
@@ -37,4 +56,7 @@
       </table>
     </div>
   </div>
+
+  <%= pagination_links(@pending_changes, [next: "Next", previous: "Previous"] ++ query_params(@conn)) %>
+
 </section>

--- a/lib/companies_web/templates/admin/pending_change/show.html.eex
+++ b/lib/companies_web/templates/admin/pending_change/show.html.eex
@@ -21,7 +21,7 @@
         <div class="changes is-hidden"><pre><%= to_json(@pending_change.changes) %></pre></div>
         <div class="original is-hidden"><pre><%= to_json(@pending_change.original)%></pre></div>
       </div>
-      <%= if pending_approval?(@pending_change.approved) do %>
+      <%= if pending_approval?(@pending_change) do %>
         <%= form_tag(Routes.pending_change_path(@conn, :update, locale(@conn), @pending_change.id), method: "PATCH") do %>
           <div class="field is-grouped is-grouped-centered">
             <div class="control">

--- a/lib/companies_web/templates/admin/pending_change/show.html.eex
+++ b/lib/companies_web/templates/admin/pending_change/show.html.eex
@@ -2,7 +2,7 @@
   <div class="columns is-centered">
     <div class="column is-half">
       <span class="has-text-centered">
-        <h2 class="title is-2">Pending Change</h2>
+        <h2 class="title is-2"><%= pending_change_title(@pending_change) %></h2>
       </span>
       <span class="has-text-centered">
         <h2 class="title is-5">Requested by: <a href="https://github.com/<%= @pending_change.user.nickname %>" target="_blank"><%= @pending_change.user.nickname %></a></h2>
@@ -21,18 +21,18 @@
         <div class="changes is-hidden"><pre><%= to_json(@pending_change.changes) %></pre></div>
         <div class="original is-hidden"><pre><%= to_json(@pending_change.original)%></pre></div>
       </div>
-
-      <%= form_tag(Routes.pending_change_path(@conn, :update, locale(@conn), @pending_change.id), method: "PATCH") do %>
-        <div class="field is-grouped is-grouped-centered">
-          <div class="control">
-            <%= submit("Approve", class: "button is-primary", name: "approval", value: "true") %>
+      <%= if pending_approval?(@pending_change.approved) do %>
+        <%= form_tag(Routes.pending_change_path(@conn, :update, locale(@conn), @pending_change.id), method: "PATCH") do %>
+          <div class="field is-grouped is-grouped-centered">
+            <div class="control">
+              <%= submit("Approve", class: "button is-primary", name: "approval", value: "true") %>
+            </div>
+            <div class="control">
+              <%= submit("Reject", class: "button is-danger", name: "approval", value: "false") %>
+            </div>
           </div>
-          <div class="control">
-            <%= submit("Reject", class: "button is-danger", name: "approval", value: "false") %>
-          </div>
-        </div>
+        <% end %>
       <% end %>
-
     </div>
   </div>
 </div>

--- a/lib/companies_web/views/admin/pending_change_view.ex
+++ b/lib/companies_web/views/admin/pending_change_view.ex
@@ -1,7 +1,20 @@
 defmodule CompaniesWeb.Admin.PendingChangeView do
   use CompaniesWeb, :view
 
+  import Scrivener.HTML
+
   def to_json(map) do
     Jason.encode!(map, pretty: true)
   end
+
+  def pending_change_title(%{approved: nil}), do: gettext("Pending Change")
+  def pending_change_title(%{approved: true}), do: gettext("Approved Change")
+  def pending_change_title(%{approved: false}), do: gettext("Rejected Change")
+
+  def pending_changes_title(%{params: %{"approved" => "true"}}), do: gettext("Approved Changes")
+  def pending_changes_title(%{params: %{"approved" => "false"}}), do: gettext("Rejected Changes")
+  def pending_changes_title(_), do: gettext("Pending Changes")
+
+  def pending_approval?(%{approved: nil}), do: true
+  def pending_approval?(_), do: false
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -227,3 +227,39 @@ Repo.insert!(%PendingChange{
   resource: "company",
   user_id: system.id
 })
+
+# Denied change
+Repo.insert!(%PendingChange{
+  action: "create",
+  approved: false,
+  changes: %{
+    name: "spam",
+    description: """
+    spam spam.
+    """,
+    github: "https://github.com/spam",
+    industry_id: technology_consulting.id,
+    location: "Global",
+    url: "https://spam.io"
+  },
+  resource: "company",
+  user_id: system.id
+})
+
+# Approved change
+Repo.insert!(%PendingChange{
+  action: "create",
+  approved: true,
+  changes: %{
+    name: "Awkward",
+    description: """
+    Awkward is a digital product company based in Rotterdam, the Netherlands. We help our clients realize ideas from the first sketch, to launch day and beyond.
+    """,
+    github: "https://github.com/awkward",
+    industry_id: technology_consulting.id,
+    location: "Rotterdam, the Netherlands",
+    url: "https://awkward.co"
+  },
+  resource: "company",
+  user_id: system.id
+})

--- a/test/companies_web/controllers/company_controller_test.exs
+++ b/test/companies_web/controllers/company_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule CompaniesWeb.CompanyControllerTest do
   use CompaniesWeb.ConnCase
 
+  @moduletag capture_log: true
+
   test "GET / without locale", %{conn: conn} do
     conn = get(conn, "/")
     assert redirected_to(conn, 302) == "/en"


### PR DESCRIPTION
With pending changes happening on the site I figured there should be a way to see the rejected and approved changes.

This PR changes the pending changes index and adds three buttons to show the pending changes/approved changes or the rejected changes. 

It also adds pagination to the page as otherwise it would show all changes so far on the site on a single page.

It also changes the url of `/en/admin/pending` to `/en/admin/changes` as I felt it would better capture the contents.