### PR TITLE
Add locale to path helper

### DIFF
--- a/lib/companies_web/controllers/auth_controller.ex
+++ b/lib/companies_web/controllers/auth_controller.ex
@@ -27,12 +27,12 @@ defmodule CompaniesWeb.AuthController do
         conn
         |> put_flash(:info, "Welcome!")
         |> put_session(:user_id, user.id)
-        |> redirect(to: Routes.company_path(conn, :recent))
+        |> redirect(to: Routes.company_path(conn, :recent, "en"))
 
       {:error, reason} ->
         conn
         |> put_flash(:error, "Error: #{reason}")
-        |> redirect(to: Routes.company_path(conn, :recent))
+        |> redirect(to: Routes.company_path(conn, :recent, "en"))
     end
   end
 end


### PR DESCRIPTION
The path to admin changed but we forgot to update the helpers to include the locale, this PR does that. The change has already been deployed to Heroku to confirm it works.