### PR TITLE
Trim whitespace from search text before query

### DIFF
--- a/lib/companies/companies.ex
+++ b/lib/companies/companies.ex
@@ -52,6 +52,8 @@ defmodule Companies.Companies do
   end
 
   defp query_predicates({"text", text}, query) do
+    text = String.trim(text)
+
     from c in query, where: ilike(c.name, ^"%#{text}%")
   end
 

--- a/test/companies/companies_test.exs
+++ b/test/companies/companies_test.exs
@@ -36,6 +36,16 @@ defmodule Companies.CompaniesTest do
 
       assert %{entries: [%{name: "ALPHA"}]} = Companies.all(%{"search" => %{"text" => "lp"}})
     end
+
+    test "trims leading and trailing whitespace on text search" do
+      insert(:company, name: "ZULU")
+      insert(:company, name: "BETA")
+      insert(:company, name: "ALPHA")
+
+      assert %{entries: [%{name: "ALPHA"}]} = Companies.all(%{"search" => %{"text" => "alpha "}})
+      assert %{entries: [%{name: "ALPHA"}]} = Companies.all(%{"search" => %{"text" => " alpha"}})
+      assert %{entries: [%{name: "ALPHA"}]} = Companies.all(%{"search" => %{"text" => " alpha "}})
+    end
   end
 
   describe "recent/1" do


### PR DESCRIPTION
I was searching for DockYard this morning but the iOS autocomplete appended a space creating a search like "DockYard ", causing no results to be returned. This PR trims the leading and trailing whitespace before building the database query.