### PR TITLE
Trim leading and trailing whitespace on job search

### DIFF
--- a/lib/companies/jobs.ex
+++ b/lib/companies/jobs.ex
@@ -121,6 +121,8 @@ defmodule Companies.Jobs do
   end
 
   defp query_predicates({"text", text}, query) do
+    text = String.trim(text)
+
     from c in query, where: ilike(c.title, ^"%#{text}%")
   end
 

--- a/test/companies/jobs_test.exs
+++ b/test/companies/jobs_test.exs
@@ -25,6 +25,15 @@ defmodule Companies.JobsTest do
 
       assert 1 == length(entries)
     end
+
+    test "trims leading and trailing whitespace on text search" do
+      insert(:job, title: "test job")
+      insert(:job, title: "alternate")
+
+      assert %{entries: [%{title: "test job"}]} = Jobs.all(%{"search" => %{"text" => "job "}})
+      assert %{entries: [%{title: "test job"}]} = Jobs.all(%{"search" => %{"text" => " job"}})
+      assert %{entries: [%{title: "test job"}]} = Jobs.all(%{"search" => %{"text" => " job "}})
+    end
   end
 
   describe "create/2" do


### PR DESCRIPTION
This is a follow up to #563 to trim leading and trailing whitespace when searching by job title.