### PR TITLE
URL should be capitalized as it's an acronym

### DIFF
--- a/lib/companies_web/templates/job/form.html.eex
+++ b/lib/companies_web/templates/job/form.html.eex
@@ -20,7 +20,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :url, gettext("Url"), class: "field" %>
+    <%= label f, :url, gettext("URL"), class: "field" %>
     <div class="control">
       <%= text_input f, :url, class: input_class(@changeset, :url) %>
       <%= error_tag f, :url %>

--- a/lib/companies_web/templates/user/form.html.eex
+++ b/lib/companies_web/templates/user/form.html.eex
@@ -14,7 +14,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :cv_url, gettext("CV Url"), class: "field" %>
+    <%= label f, :cv_url, gettext("CV URL"), class: "field" %>
     <div class="control">
       <%= text_input f, :cv_url, class: "input" %>
       <%= error_tag f, :cv_url %>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -200,7 +200,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/companies_web/templates/job/form.html.eex:23
-msgid "Url"
+msgid "URL"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -122,11 +122,6 @@ msgid "Title:"
 msgstr ""
 
 #, elixir-format
-#: lib/companies_web/templates/job/show.html.eex:11
-msgid "Url:"
-msgstr ""
-
-#, elixir-format
 #: lib/companies_web/templates/company/recent.html.eex:9
 msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
 msgstr ""

--- a/priv/gettext/el/LC_MESSAGES/default.po
+++ b/priv/gettext/el/LC_MESSAGES/default.po
@@ -201,7 +201,7 @@ msgstr "Τίτλος"
 
 #, elixir-format
 #: lib/companies_web/templates/job/form.html.eex:23
-msgid "Url"
+msgid "URL"
 msgstr "Σύνδεσμος"
 
 #, elixir-format

--- a/priv/gettext/el/LC_MESSAGES/default.po
+++ b/priv/gettext/el/LC_MESSAGES/default.po
@@ -123,11 +123,6 @@ msgid "Title:"
 msgstr "Τίτλος:"
 
 #, elixir-format
-#: lib/companies_web/templates/job/show.html.eex:11
-msgid "Url:"
-msgstr "Σύνδεσμος:"
-
-#, elixir-format
 #: lib/companies_web/templates/company/recent.html.eex:9
 msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
 msgstr "%{companies_count} εταιρείες και συνεχίζουμε..."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -123,11 +123,6 @@ msgid "Title:"
 msgstr ""
 
 #, elixir-format
-#: lib/companies_web/templates/job/show.html.eex:11
-msgid "Url:"
-msgstr ""
-
-#, elixir-format
 #: lib/companies_web/templates/company/recent.html.eex:9
 msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -201,7 +201,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/companies_web/templates/job/form.html.eex:23
-msgid "Url"
+msgid "URL"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -123,11 +123,6 @@ msgid "Title:"
 msgstr "Залоговок:"
 
 #, elixir-format
-#: lib/companies_web/templates/job/show.html.eex:11
-msgid "Url:"
-msgstr "Адрес:"
-
-#, elixir-format
 #: lib/companies_web/templates/company/recent.html.eex:9
 msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
 msgstr "Уже <span class='has-text-weight-semibold'>%{companies_count}</span> и продолжаем искать..."

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -201,7 +201,7 @@ msgstr "Заголовок"
 
 #, elixir-format
 #: lib/companies_web/templates/job/form.html.eex:23
-msgid "Url"
+msgid "URL"
 msgstr "Адрес"
 
 #, elixir-format


### PR DESCRIPTION
This PR:

* Capitalizes the word URL since it's an acronym
* Removes some unused translations

I've not used `gettext` before so I think this is correct.

I've also removed some translations that aren't required any more since the [job show template was removed in a previous PR](https://github.com/beam-community/elixir-companies/pull/598/files#diff-af9e61a4dc933beb71cff26f5e10fe17).

| Before  | After |
| ------------- | ------------- |
| <img width="822" alt="before" src="https://user-images.githubusercontent.com/6588/76262021-41903980-6253-11ea-9169-8b31ca16a43a.png">  | <img width="822" alt="after" src="https://user-images.githubusercontent.com/6588/76262023-42c16680-6253-11ea-8e84-47c46823560c.png">  |
