### PR TITLE
Fix: Pending Change CRUD for admins

### DIFF
--- a/lib/companies/pending_changes.ex
+++ b/lib/companies/pending_changes.ex
@@ -98,7 +98,7 @@ defmodule Companies.PendingChanges do
 
     module
     |> Repo.get(id)
-    |> Repo.preload(:removed_pending_change)
+    |> Repo.preload(removed_pending_change: [:user, :reviewer])
     |> drop_ecto_fields()
     |> drop_nulls()
   end

--- a/lib/companies/schema/pending_change.ex
+++ b/lib/companies/schema/pending_change.ex
@@ -7,6 +7,8 @@ defmodule Companies.Schema.PendingChange do
 
   alias Companies.Schema.User
 
+  @derive {Jason.Encoder,
+           only: [:action, :approved, :changes, :note, :resource, :original, :user, :user_id, :reviewer, :reviewer_id]}
   schema "pending_changes" do
     field :action, :string
     field :approved, :boolean

--- a/lib/companies/schema/user.ex
+++ b/lib/companies/schema/user.ex
@@ -4,6 +4,22 @@ defmodule Companies.Schema.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder,
+           only: [
+             :email,
+             :email_notifications,
+             :token,
+             :nickname,
+             :name,
+             :image,
+             :description,
+             :bio,
+             :location,
+             :interests,
+             :cv_url,
+             :looking_for_job,
+             :maintainer
+           ]}
   schema "users" do
     field :email, :string
     field :email_notifications, :boolean


### PR DESCRIPTION
fixes: #589

- `PendingChange` and the `User` schema were missing the `Jason.Encoder`
- `PendingChange` was not preloading the `user` and the `reviewer` of `removed_pending_change`

