### PR TITLE
Move the maintainer flag to admin DB column

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,13 +27,7 @@ config :phoenix, :json_library, Jason
 config :companies,
   notifier: Notify.Console,
   site_data: %{
-    name: "Elixir Companies",
-    maintainers: [
-      "doomspork",
-      "gemantzu",
-      "tajchumber",
-      "maartenvanvliet"
-    ]
+    name: "Elixir Companies"
   },
   results_per_page: 16
 

--- a/lib/companies/accounts.ex
+++ b/lib/companies/accounts.ex
@@ -35,9 +35,7 @@ defmodule Companies.Accounts do
 
   """
   def get!(id) do
-    User
-    |> Repo.get!(id)
-    |> maintainer_status()
+    Repo.get!(User, id)
   end
 
   @doc """
@@ -59,7 +57,6 @@ defmodule Companies.Accounts do
       on_conflict: {:replace, [:token, :name, :nickname, :image, :description, :bio, :location]},
       conflict_target: :email
     )
-    |> maintainer_status()
   end
 
   def change(%User{} = user) do
@@ -74,30 +71,11 @@ defmodule Companies.Accounts do
 
     query
     |> Repo.one()
-    |> maintainer_status()
   end
 
   def update(%User{} = user, attrs) do
     user
     |> User.profile_changeset(attrs)
     |> Repo.update()
-  end
-
-  defp maintainer_status({:error, reason}) do
-    {:error, reason}
-  end
-
-  defp maintainer_status({:ok, user}) do
-    {:ok, maintainer_status(user)}
-  end
-
-  defp maintainer_status(%{nickname: nickname} = user) do
-    %{user | maintainer: nickname in maintainers()}
-  end
-
-  defp maintainers do
-    :companies
-    |> Application.get_env(:site_data)
-    |> Map.get(:maintainers)
   end
 end

--- a/lib/companies/schema/user.ex
+++ b/lib/companies/schema/user.ex
@@ -6,6 +6,7 @@ defmodule Companies.Schema.User do
 
   @derive {Jason.Encoder,
            only: [
+             :admin,
              :email,
              :email_notifications,
              :token,
@@ -17,10 +18,10 @@ defmodule Companies.Schema.User do
              :location,
              :interests,
              :cv_url,
-             :looking_for_job,
-             :maintainer
+             :looking_for_job
            ]}
   schema "users" do
+    field :admin, :boolean, default: false
     field :email, :string
     field :email_notifications, :boolean
     field :token, :string
@@ -33,8 +34,6 @@ defmodule Companies.Schema.User do
     field :interests, :string
     field :cv_url, :string
     field :looking_for_job, :boolean
-
-    field :maintainer, :boolean, default: false, virtual: true
 
     timestamps()
   end

--- a/lib/companies_web/helpers/site_helpers.ex
+++ b/lib/companies_web/helpers/site_helpers.ex
@@ -7,8 +7,6 @@ defmodule CompaniesWeb.SiteHelpers do
   def query_params(%{query_params: %{"approved" => approved}}), do: [approved: approved]
   def query_params(_), do: []
 
-  def maintainers, do: Map.get(site_data(), :maintainers)
-
   def site_description, do: gettext("A collection of companies using Elixir in production.")
 
   def site_title, do: Map.get(site_data(), :name)

--- a/lib/companies_web/helpers/user_helpers.ex
+++ b/lib/companies_web/helpers/user_helpers.ex
@@ -3,7 +3,7 @@ defmodule CompaniesWeb.UserHelpers do
 
   def admin_session?(conn) do
     case current_user(conn) do
-      %{maintainer: true} -> true
+      %{admin: true} -> true
       _ -> false
     end
   end

--- a/lib/companies_web/plugs/authorize.ex
+++ b/lib/companies_web/plugs/authorize.ex
@@ -1,6 +1,6 @@
 defmodule CompaniesWeb.Plugs.Authorize do
   @moduledoc """
-  A simple plug to prevent users without maintainer status from continuing
+  A simple plug to prevent users without admin status from continuing
   """
 
   import CompaniesWeb.LocaleHelpers, only: [locale: 1]
@@ -11,7 +11,7 @@ defmodule CompaniesWeb.Plugs.Authorize do
 
   def init(opts), do: opts
 
-  def call(%{assigns: %{current_user: %{maintainer: true}}} = conn, maintainer: true) do
+  def call(%{assigns: %{current_user: %{admin: true}}} = conn, admin: true) do
     conn
   end
 

--- a/lib/companies_web/router.ex
+++ b/lib/companies_web/router.ex
@@ -19,7 +19,7 @@ defmodule CompaniesWeb.Router do
   end
 
   pipeline :admin do
-    plug CompaniesWeb.Plugs.Authorize, maintainer: true
+    plug CompaniesWeb.Plugs.Authorize, admin: true
   end
 
   pipeline :set_locale do

--- a/lib/companies_web/templates/layout/footer.html.eex
+++ b/lib/companies_web/templates/layout/footer.html.eex
@@ -5,13 +5,6 @@
       <span class="has-text-weight-semibold">
         <%= site_title() %>
       </span>
-      <%= gettext("is maintained by") %>
-      <%= for maintainer <- maintainers() do %>
-        <a class="has-text-weight-semibold" href="https://github.com/<%= maintainer %>">
-          @<%= maintainer %>
-        </a>
-      <% end %>
-      <%= gettext(" and a team of contributors!") %>
       </p>
       <p>
       <%= gettext("Made possible with support from") %>

--- a/priv/repo/migrations/20200418145204_add_users_admin_flag.exs
+++ b/priv/repo/migrations/20200418145204_add_users_admin_flag.exs
@@ -1,0 +1,9 @@
+defmodule Companies.Repo.Migrations.AddUsersAdminFlag do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :admin, :boolean, default: false
+    end
+  end
+end

--- a/test/companies/accounts_test.exs
+++ b/test/companies/accounts_test.exs
@@ -4,26 +4,22 @@ defmodule Companies.AccountsTest do
   alias Companies.Accounts
 
   describe "create/1" do
-    test "creates a new account and assigns maintainer status" do
-      assert {:ok, %{id: _id, maintainer: true}} =
-               Accounts.create(%{email: "test@example.com", nickname: "doomspork", token: "abc123"})
+    test "creates a new account" do
+      assert {:ok, %{id: _id}} = Accounts.create(%{email: "test@example.com", nickname: "doomspork", token: "abc123"})
     end
   end
 
   describe "get!/1" do
-    test "gets a user and assigns maintainer status" do
-      %{id: maintainer_id} = insert(:user, nickname: "doomspork")
-      assert %{maintainer: true} = Accounts.get!(maintainer_id)
-
-      %{id: nonmaintainer_id} = insert(:user)
-      assert %{maintainer: false} = Accounts.get!(nonmaintainer_id)
+    test "gets a user" do
+      %{id: admin_id} = insert(:user, nickname: "doomspork", admin: true)
+      assert %{admin: true} = Accounts.get!(admin_id)
     end
   end
 
   describe "get_user_by_email/1" do
     test "gets a user by email" do
       %{email: email, id: id} = insert(:user)
-      assert %{email: ^email, maintainer: false, id: ^id} = Accounts.get_by_email(email)
+      assert %{email: ^email, admin: false, id: ^id} = Accounts.get_by_email(email)
     end
   end
 

--- a/test/companies/pending_changes_test.exs
+++ b/test/companies/pending_changes_test.exs
@@ -46,7 +46,7 @@ defmodule Companies.PendingChangesTest do
       %{total_entries: pre_count} = Companies.all()
 
       %{id: id} = insert(:pending_change)
-      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:maintainer), true)
+      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:admin), true)
       assert Enum.empty?(PendingChanges.all())
 
       %{total_entries: post_count} = Companies.all()
@@ -59,7 +59,7 @@ defmodule Companies.PendingChangesTest do
       %{id: company_id} = insert(:company)
       %{id: id} = insert(:pending_change, %{action: "update", changes: %{id: company_id, name: "updated"}})
 
-      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:maintainer), true)
+      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:admin), true)
       assert %{entries: [%{name: "updated"}], total_entries: 1} = Companies.all()
       assert_email_delivered_with(subject: @email_subject_approval)
     end
@@ -68,7 +68,7 @@ defmodule Companies.PendingChangesTest do
       %{id: company_id} = insert(:company)
       %{id: id} = insert(:pending_change, %{action: "delete", changes: %{id: company_id, name: "elixir-companies"}})
 
-      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:maintainer), true)
+      assert {:ok, %{approved: true}} = PendingChanges.approve(id, @note, insert(:admin), true)
       assert %{total_entries: 0} = Companies.all()
       assert_email_delivered_with(subject: @email_subject_approval)
       assert %{removed_pending_change_id: id} = Repo.get!(Company, company_id)
@@ -78,7 +78,7 @@ defmodule Companies.PendingChangesTest do
       %{total_entries: pre_count} = Companies.all()
 
       %{id: id} = insert(:pending_change)
-      assert {:ok, %{approved: false}} = PendingChanges.approve(id, @note, insert(:maintainer), false)
+      assert {:ok, %{approved: false}} = PendingChanges.approve(id, @note, insert(:admin), false)
       assert Enum.empty?(PendingChanges.all())
 
       assert %{total_entries: ^pre_count} = Companies.all()
@@ -86,7 +86,7 @@ defmodule Companies.PendingChangesTest do
     end
 
     test "returns an error for missing changes" do
-      assert {:error, "change not found"} = PendingChanges.approve(-1, @note, insert(:maintainer), true)
+      assert {:error, "change not found"} = PendingChanges.approve(-1, @note, insert(:admin), true)
     end
   end
 
@@ -122,7 +122,7 @@ defmodule Companies.PendingChangesTest do
       %{id: delete_change_id} =
         insert(:pending_change, %{action: "delete", changes: %{id: company_id, name: "elixir-companies"}})
 
-      PendingChanges.approve(delete_change_id, @note, insert(:maintainer), true)
+      PendingChanges.approve(delete_change_id, @note, insert(:admin), true)
       %{id: id} = insert(:pending_change, %{action: "update", changes: %{id: company_id, name: "updated"}})
 
       %{original: %{removed_pending_change: removed_pending_change}} = PendingChanges.get(id)

--- a/test/companies_web/plugs/authorize_test.exs
+++ b/test/companies_web/plugs/authorize_test.exs
@@ -10,7 +10,7 @@ defmodule CompaniesWeb.Plugs.AuthorizeTest do
       user =
         :user
         |> build()
-        |> Map.put(:maintainer, false)
+        |> Map.put(:admin, false)
 
       assert %{halted: false} =
                build_conn()
@@ -18,29 +18,29 @@ defmodule CompaniesWeb.Plugs.AuthorizeTest do
                |> Authorize.call([])
     end
 
-    test "allows logged in maintainers to continue" do
+    test "allows logged in admins to continue" do
       user =
         :user
         |> build()
-        |> Map.put(:maintainer, true)
+        |> Map.put(:admin, true)
 
       assert %{halted: false} =
                build_conn()
                |> assign(:current_user, user)
-               |> Authorize.call(maintainer: true)
+               |> Authorize.call(admin: true)
     end
 
-    test "prohibits logged in users from accessing maintainer only routes" do
+    test "prohibits logged in users from accessing admin only routes" do
       user =
         :user
         |> build()
-        |> Map.put(:maintainer, false)
+        |> Map.put(:admin, false)
 
       assert build_conn()
              |> with_session()
              |> fetch_flash()
              |> assign(:current_user, user)
-             |> Authorize.call(maintainer: true)
+             |> Authorize.call(admin: true)
              |> redirected_to(401) =~ "/"
     end
 

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -53,7 +53,7 @@ defmodule Companies.Factory do
     }
   end
 
-  def maintainer_factory do
-    %{build(:user) | maintainer: true}
+  def admin_factory do
+    %{build(:user) | admin: true}
   end
 end


### PR DESCRIPTION
This is something I've been meaning to do ever since we moved to this application. Now that I'm going through and doing cleanup, I wanted to hit this.

Nice to have feature I may get to: add beam-community members as admins when they create an account.