### PR TITLE
Upgrade elixir

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 # Erlang version
-erlang_version=21.1
+erlang_version=22.3
 
 # Elixir version
-elixir_version=1.7.4
+elixir_version=1.10.0

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Companies.MixProject do
     [
       app: :companies,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Heroku build failed because some features in master were from newer Elixir version, 1.8, so just bumped to latest 1.10