### PR TITLE
Force ssl redirect

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,7 +13,15 @@ config :companies, CompaniesWeb.Endpoint,
   http: [:inet6, port: System.get_env("PORT") || 4000],
   url: [scheme: "https", host: "elixir-companies.com"],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  secret_key_base: System.get_env("SECRET_KEY_BASE")
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
+  https: [
+    port: 443,
+    cipher_suite: :strong,
+    otp_app: :companies,
+    keyfile: System.get_env("COMPANIES_SSL_KEY_PATH"),
+    certfile: System.get_env("COMPANIES_SSL_CERT_PATH")
+  ],
+  force_ssl: [rewrite_on: [:x_forwarded_proto]]
 
 config :companies, :notifier, Notify.Slack
 


### PR DESCRIPTION
The site does not currently force ssl redirects when accessed via http.

It should be noted that `COMPANIES_SSL_KEY_PATH` and `COMPANIES_SSL_CERT_PATH` would need to be set at build time in order for The get_env calls to properly set the keyfile and certfile locations. I believe you have this deployed to heroku, but I don't know enough about heroku deployments to say exactly what these paths should be. 