### PR TITLE
Remove bio field from user

### DIFF
--- a/lib/companies/accounts.ex
+++ b/lib/companies/accounts.ex
@@ -86,7 +86,7 @@ defmodule Companies.Accounts do
     %User{}
     |> User.changeset(attrs)
     |> Repo.insert(
-      on_conflict: {:replace, [:token, :name, :nickname, :image, :description, :bio, :location]},
+      on_conflict: {:replace, [:token, :name, :nickname, :image, :description, :location]},
       conflict_target: :email
     )
   end

--- a/lib/companies/schema/user.ex
+++ b/lib/companies/schema/user.ex
@@ -14,7 +14,6 @@ defmodule Companies.Schema.User do
              :name,
              :image,
              :description,
-             :bio,
              :location,
              :interests,
              :cv_url,
@@ -29,7 +28,6 @@ defmodule Companies.Schema.User do
     field :name, :string
     field :image, :string
     field :description, :string
-    field :bio, :string
     field :location, :string
     field :interests, :string
     field :cv_url, :string
@@ -41,7 +39,7 @@ defmodule Companies.Schema.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:email, :email_notifications, :nickname, :token, :name, :image, :description, :bio, :location])
+    |> cast(attrs, [:email, :email_notifications, :nickname, :token, :name, :image, :description, :location])
     |> validate_required([:email, :nickname, :token])
   end
 

--- a/lib/companies_web/controllers/auth_controller.ex
+++ b/lib/companies_web/controllers/auth_controller.ex
@@ -13,7 +13,6 @@ defmodule CompaniesWeb.AuthController do
       name: auth.info.name,
       image: auth.info.image,
       description: auth.info.description,
-      bio: auth.extra.raw_info.user["bio"],
       location: auth.info.location
     }
 

--- a/lib/companies_web/templates/user/profile.html.eex
+++ b/lib/companies_web/templates/user/profile.html.eex
@@ -30,15 +30,6 @@
           <%= @user.email %>
           <br>
         </p>
-        <%= if @user.bio do %>
-        <p class="is-size-5">
-          <span class="icon purple">
-            <i class="far fa-address-card"></i>
-          </span>
-          <%= @user.bio %>
-          <br>
-        </p>
-        <% end %>
         <%= if @user.description do %>
         <p class="is-size-5">
           <span class="icon purple">

--- a/priv/repo/migrations/20210429010415_remove_user_bio.exs
+++ b/priv/repo/migrations/20210429010415_remove_user_bio.exs
@@ -1,0 +1,9 @@
+defmodule Companies.Repo.Migrations.RemoveUserBio do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :bio
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -44,7 +44,6 @@ defmodule Companies.Factory do
       email: sequence(:email, &"user-#{&1}@example.com"),
       token: "abc1234",
       name: "test name",
-      bio: "test bio",
       description: "test description",
       location: "test location",
       interests: "test interests",


### PR DESCRIPTION
It's just a duplicate of the description field. If you look at any profile, it gives the same line twice. If you look at the Ueberauth GitHub library, they were already assigning GitHub's bio into description.
