### PR TITLE
Default sort to desc, not asc

### DIFF
--- a/lib/companies/helper.ex
+++ b/lib/companies/helper.ex
@@ -37,6 +37,6 @@ defmodule Companies.Helpers do
     {field, direction}
   end
 
-  defp sorting_direction(%{"order" => "desc"}), do: :desc
-  defp sorting_direction(_params), do: :asc
+  defp sorting_direction(%{"order" => "asc"}), do: :asc
+  defp sorting_direction(_params), do: :desc
 end


### PR DESCRIPTION
Noticed this today after adding a new company and they're not on the homepage