### PR TITLE
Add merge group to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 env:
   CACHE_VERSION: v1


### PR DESCRIPTION
Adding `merge_group` to when workflows should fire per: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions