### PR TITLE
Add company updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ A [collection of companies using Elixir](https://elixir-companies.com/) in produ
 
 Proudly built with [Phoenix](https://phoenixframework.org).
 
-### Adding a new company to the list
+### Adding a new company be showcased
 
-Add your company information to a new `/priv/companies/{{company}}.exs` in the following format:
+- Fork the repo
+- Add your company information to a new `/priv/companies/{{company}}.exs` in the following format:
 
 ```elixir
 %{
@@ -30,20 +31,28 @@ Add your company information to a new `/priv/companies/{{company}}.exs` in the f
 }
 ```
 
+- Create a pull request adding the new company file
+
 ## Development
 
-1. Install dependencies with `mix deps.get`
-1. Create and migrate your database with `mix ecto.setup`
-1. Install Node.js dependencies with `cd assets && npm install`
+1. Install current elixir, erlang and nodejs versions
+
+   1. This project uses [asdf](https://asdf-vm.com/) to manage the language versions of the project.
+   1. Follow the instructions on [asdf#getting-started](https://asdf-vm.com/guide/getting-started.html) to install asdf.
+   1. Once complete, run the following command to install the language versions:
+
+   ```sh
+   asdf install
+   ```
+
+   -- OR --
+
+   1. If you manage your language versions differently, please reference [~/.tool-versions](.tool-versions) for the specific versions to run the project.
+
+1. Install elixir and nodejs dependencies with `mix setup`
 1. Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-_Note_: You need to set up a [GitHub Application](https://developer.github.com/) and ensure `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are available to your application. The GitHub application needs its callback set to `http://localhost:4000/auth/github/callback` and be given read-only access to the email addresses of the user.
-
-_Note_: You need to have Postgres version 9.5+, due to our use of certain features that are fairly new (JSONB Data Type + ON CONFLICT query).
-
-_Note_: If for some reason you reset the database on your machine, you will see an error as the browser has cookies for a user that does not exist in the database. You will need to clear the cookies and site data for the page on your browser and refresh the page to remove the error.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,25 @@ Proudly built with [Phoenix](https://phoenixframework.org).
 
 ### Adding a new company to the list
 
-- Sign with your GitHub account.
-- Click on `Add a company` button and you will be redirected to a form.
-- Fill all required data about the company and submit it.
+Add your company information to a new `/priv/companies/{{company}}.exs` in the following format:
 
-After that, the admin needs to validate the request.
-
-With everything OK the company will be approved and will appear in companies list.
-
-### Adding a new job opportunity for a company
-
-Once your company is available on the list, you are able to add a new Job opportunity for the given company.
-
-- Sign with your GitHub account.
-- Click on `+ Add a Job` link and you will be redirected to a form.
-- Fill all required data about the company and submit it.
+```elixir
+%{
+  name: "Elixir Companies",
+  website: "https://elixir-companies.com/",
+  github: "https://github.com/beam-community/elixir-companies",
+  industry: "Technology",
+  location: %{
+    city: "Atlanta",
+    state: "GA",
+    country: "USA"
+  },
+  description: """
+  Elixir Companies showcases all the companies that utilize elixir in their technology stack.
+  """,
+  last_changed_on: ~D[2024-01-01]
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,25 +11,36 @@ Proudly built with [Phoenix](https://phoenixframework.org).
 ### Adding a new company be showcased
 
 - Fork the repo
-- Add your company information to a new `/priv/companies/{{company}}.exs` in the following format:
+- Use the helper Mix task to generate the file:
+  ```sh
+  mix create_company_file {{ your company name }}
+  ```
 
-```elixir
-%{
-  name: "Elixir Companies",
-  website: "https://elixir-companies.com/",
-  github: "https://github.com/beam-community/elixir-companies",
-  industry: "Technology",
-  location: %{
-    city: "Atlanta",
-    state: "GA",
-    country: "USA"
-  },
-  description: """
-  Elixir Companies showcases all the companies that utilize elixir in their technology stack.
-  """,
-  last_changed_on: ~D[2024-01-01]
-}
-```
+**-- OR --**
+
+- Add your company information to a new `/priv/companies/{{company_name}}.exs` in the following format:
+
+  ```elixir
+  # Company file for Acme Corp
+  # Created on: 2024-01-01
+
+  %{
+    name: "Acme Corp",
+    website: "https://example.com/",
+    github: "https://github.com/example/acme-corp",
+    # reference lib/companies/industries.ex for a list of recommended industries to use here
+    industry: "Technology",
+    location: %{
+      city: "City",
+      state: "State",
+      country: "Country"
+    },
+    description: """
+    Description of Acme Corp goes here.
+    """,
+    last_changed_on: ~D[2024-01-01]
+  }
+  ```
 
 - Create a pull request adding the new company file
 
@@ -41,11 +52,11 @@ Proudly built with [Phoenix](https://phoenixframework.org).
    1. Follow the instructions on [asdf#getting-started](https://asdf-vm.com/guide/getting-started.html) to install asdf.
    1. Once complete, run the following command to install the language versions:
 
-   ```sh
-   asdf install
-   ```
+      ```sh
+      asdf install
+      ```
 
-   -- OR --
+   **-- OR --**
 
    1. If you manage your language versions differently, please reference [~/.tool-versions](.tool-versions) for the specific versions to run the project.
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -18,13 +18,19 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.7.14",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.3.4"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1"
+      "version": "0.20.17",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "^1.43.1",
+        "monocart-reporter": "^2.3.1"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -2603,7 +2609,11 @@
       "version": "file:../deps/phoenix_html"
     },
     "phoenix_live_view": {
-      "version": "file:../deps/phoenix_live_view"
+      "version": "file:../deps/phoenix_live_view",
+      "requires": {
+        "@playwright/test": "^1.43.1",
+        "monocart-reporter": "^2.3.1"
+      }
     },
     "picocolors": {
       "version": "1.0.1",

--- a/lib/companies_web/templates/layout/navbar.html.eex
+++ b/lib/companies_web/templates/layout/navbar.html.eex
@@ -18,6 +18,7 @@
         <%= link gettext("Companies"), to: Routes.live_path(@conn, CompaniesWeb.CompanyLive, locale(@conn)), class: "navbar-item" %>
       </div>
       <div class="navbar-end">
+        <%= link gettext("Add a company"), to: "https://github.com/beam-community/elixir-companies?tab=readme-ov-file", class: "button is-link mr-2" %>
         <div class="field is-grouped">
           <%= render "locales.html", conn: @conn %>
         </div>

--- a/lib/mix/tasks/create_company_file.ex
+++ b/lib/mix/tasks/create_company_file.ex
@@ -1,0 +1,75 @@
+# lib/mix/tasks/create_company_file.ex
+defmodule Mix.Tasks.CreateCompanyFile do
+  use Mix.Task
+  require Logger
+
+  @shortdoc "Creates a company file in the priv/companies directory"
+
+  @moduledoc """
+  Scaffold company file in desired format to render by UI
+
+    $ mix create_company_file Acme Corp
+    $ mix create_company_file "Acme Corp"
+    $ mix create_company_file Acme   Corp
+  """
+
+  @impl Mix.Task
+  @doc false
+  def run(args) do
+    case parse_args(args) do
+      "" ->
+        Logger.error("Expected at least one argument: the company name")
+        Logger.info("Usage: mix create_company_file COMPANY_NAME")
+
+      company_name ->
+        maybe_create_file(company_name)
+    end
+  end
+
+  defp parse_args(args) do
+    args
+    |> Enum.flat_map(&String.split(&1, ~r{\s}, trim: true))
+    |> Enum.join(" ")
+    |> String.trim()
+  end
+
+  defp maybe_create_file(company_name) do
+    file_name = company_name |> String.replace(" ", "_") |> String.downcase()
+    file_path = Path.join(["priv", "companies", "#{file_name}.exs"])
+
+    if File.exists?(file_path) do
+      Logger.error("Error: File already exists at #{file_path}")
+      Logger.info("Please choose a different company name or alter the existing file.")
+    else
+      content = """
+      # Company file for #{company_name}
+      # Created on: #{Date.utc_today()}
+
+      %{
+        name: "#{company_name}",
+        website: "https://example.com/",
+        github: "https://github.com/example/#{file_name}",
+        # reference lib/companies/industries.ex for a list of recommended industries to use here
+        industry: "Technology",
+        location: %{
+          city: "City",
+          state: "State",
+          country: "Country"
+        },
+        description: \"\"\"
+        Description of #{company_name} goes here.
+        \"\"\",
+        last_changed_on: ~D[#{Date.utc_today()}]
+      }
+      """
+
+      case File.write(file_path, content) do
+        :ok ->
+          Logger.info("Company file created successfully: #{file_path}")
+
+        {:error, reason} ->
+          Logger.error("Failed to create company file: #{:file.format_error(reason)}")
+      end
+    end
+  end
+end

--- a/lib/mix/tasks/create_company_file.ex
+++ b/lib/mix/tasks/create_company_file.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.CreateCompanyFile do
   @shortdoc "Creates a company file in the priv/companies directory"
 
   @moduledoc """
-  Scaffold company file in desired format to render by UI
+  Generate company file in desired location and structure to render in UI
 
     $ mix create_company_file Acme Corp
     $ mix create_company_file "Acme Corp"


### PR DESCRIPTION
fixes #677 

- Updates instructions for how to add a company to the repo. 
- Clean up readme of unneeded instructions (relating to ecto)
- Add mix task to help generate company file in desired location and structure
- Add CTA in nav bar to direct users to instructions in readme about adding a company