### PR TITLE
fix: rm non-functional industries select, make search box bigger

### DIFF
--- a/lib/companies_web/templates/company/index.html.leex
+++ b/lib/companies_web/templates/company/index.html.leex
@@ -5,17 +5,17 @@
     <div class="tabs is-centered">
       <%= form_tag "#", method: "get", phx_change: :search  %>
         <div class="columns is-desktop">
-          <div class="column is-one-third-desktop">
+          <div class="column">
             <div class="field">
               <label class="field" for="search[text]"><%= gettext("Text") %></label>
               <div class="control">
                 <div class="text">
-                  <input name="search[text]" id="search[text]" class="input" type="text" placeholder="Name or location" value="<%= @text %>"/>
+                  <input name="search[text]" id="search[text]" class="input" type="text" placeholder="Name or Industry" value="<%= @text %>"/>
                 </div>
               </div>
             </div>
           </div>
-          <div class="column">
+          <!-- <div class="column">
             <div class="field">
               <label class="field" for="search[industry_id]"><%= gettext("Industry") %></label>
               <div class="control">
@@ -31,7 +31,7 @@
                 </div>
               </div>
             </div>
-          </div>
+          </div> -->
         </div>
       </form>
     </div>

--- a/lib/companies_web/templates/company/index.html.leex
+++ b/lib/companies_web/templates/company/index.html.leex
@@ -15,23 +15,6 @@
               </div>
             </div>
           </div>
-          <!-- <div class="column">
-            <div class="field">
-              <label class="field" for="search[industry_id]"><%= gettext("Industry") %></label>
-              <div class="control">
-                <div class="select">
-                  <select id="search[industry_id]" name="search[industry_id]">
-                    <option value=""></option>
-                    <%= for {name, value} <- @industries do %>
-                      <option value="<%= value %>" <%= selected(value, @industry_id) %>>
-                        <%= name %>
-                      </option>
-                    <% end %>
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div> -->
         </div>
       </form>
     </div>


### PR DESCRIPTION
The industries dropdown was non functional as the select box was empty - [code reference](https://github.com/beam-community/elixir-companies/blob/main/lib/companies/industries.ex#L36-L38), and the search box will search on industry or company name - [code reference](https://github.com/beam-community/elixir-companies/blob/main/lib/companies/helper.ex#L15). 

Changes:
- removes industries select control
- removes class that shrunk the search input to itty bitty
- update search placeholder text to be accurate of what will be searched

## before
<img width="378" alt="Screenshot 2024-10-21 at 3 02 42 PM" src="https://github.com/user-attachments/assets/3f4b9287-fac5-4d4d-a724-16d0d966208f">

## after
<img width="360" alt="Screenshot 2024-10-21 at 3 02 55 PM" src="https://github.com/user-attachments/assets/f3664c19-dd93-46d5-b5a9-e0ab566d09c0">

