### PR TITLE
Make industry a link that searches on the companies page

### DIFF
--- a/lib/companies_web/templates/company/card.html.eex
+++ b/lib/companies_web/templates/company/card.html.eex
@@ -12,7 +12,7 @@
   <div class="content company-info has-text-left">
     <p class="is-size-7">
     <span class="icon purple"><i class="fas fa-fw fa-cogs"></i></span>
-    <%= industry_name(@company) %><br>
+    <%= link industry_name(@company), to: Routes.live_path(@conn, CompaniesWeb.CompanyLive, locale(@conn), [_target: ["search", "text"], search: [text: industry_name(@company)]]) %><br>
 
     <%= if @company.website do %>
       <span class="icon purple"><i class="fas fa-fw fa-globe"></i></span>


### PR DESCRIPTION
Updates the card to have the industry link through to be a search facet on the all companies page. This also prefills the search box with the text.

updates demonstrated: 
![demo](https://github.com/user-attachments/assets/2053262c-cf0f-4562-a796-70c8e19228f4)

