### PR TITLE
support GHA on push to main and adding to merge queue

### DIFF
--- a/.github/workflows/validate_company_industry.yml
+++ b/.github/workflows/validate_company_industry.yml
@@ -2,6 +2,10 @@ name: Validate Company Industry
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
+  merge_group:
 
 jobs:
   validate:


### PR DESCRIPTION
ISSUE: 
<img width="1176" alt="Screenshot 2024-11-01 at 11 08 30 AM" src="https://github.com/user-attachments/assets/49333cef-4d33-48df-9fa1-a52549fc4c37">

Adding things to the merge queue didn't run the validate company GHA. 

Github docs on [`merge_group`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group). 