### PR TITLE
rename caredox to schoolcare bc the website and linkedin both have that redirect

### DIFF
--- a/priv/companies/caredox.exs
+++ b/priv/companies/caredox.exs
@@ -1,5 +1,5 @@
 %{
-  industry: "Healthcare",
+  industry: "Health Care",
   website: "https://schoolcare.com/",
   github: "https://github.com/motherknows",
   location: %{

--- a/priv/companies/caredox.exs
+++ b/priv/companies/caredox.exs
@@ -1,14 +1,14 @@
 %{
   industry: "Healthcare",
-  website: "https://caredox.com",
+  website: "https://schoolcare.com/",
   github: "https://github.com/motherknows",
   location: %{
     city: "",
     state: "",
     country: ""
   },
-  name: "CareDox",
-  last_changed_on: ~D[2023-03-01],
+  name: "SchoolCare",
+  last_changed_on: ~D[2024-11-08],
   description: """
   Diverse, collaborative team of thoughtful, friendly engineers driven by mission of working with schools and school nurses to immunize all children -- even the uninsured! -- against diseases like the flu and help children with chronic illnesses (like asthma) manage their care. We take pride in our Elixir code and use CI tools to guarantee production Elixir code has high test coverage and clean compiler, Dialyzer, Credo, and Sobelow results.
   """


### PR DESCRIPTION
The website that was listed and the linkedin page both have this redirect, so updating the url and name to reflect 2024
