### PR TITLE
Default industry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Proudly built with [Phoenix](https://phoenixframework.org).
     website: "https://example.com/",
     github: "https://github.com/example/acme-corp",
     # reference lib/companies/industries.ex for a list of recommended industries to use here
-    industry: "Technology",
+    industry: "Information Technology",
     location: %{
       city: "City",
       state: "State",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Proudly built with [Phoenix](https://phoenixframework.org).
   }
   ```
 
+- Run `mix validate_company_file priv/companies/your-new-file.exs` to validate the new company file.
 - Create a pull request adding the new company file
 
 ## Development

--- a/lib/mix/tasks/create_company_file.ex
+++ b/lib/mix/tasks/create_company_file.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.CreateCompanyFile do
         website: "https://example.com/",
         github: "https://github.com/example/#{file_name}",
         # reference lib/companies/industries.ex for a list of recommended industries to use here
-        industry: "Technology",
+        industry: "Information Technology",
         location: %{
           city: "City",
           state: "State",


### PR DESCRIPTION
In #732 I just assumed that the `industry` I got from the mix task was a valid alternative, which it wasn't. I'm thinking that it makes sense to have a valid alternative.

I also add a reference to the `validate_company_file` so one can run the validation before creating a PR.