### PR TITLE
fix: run CI on merge queue branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
Hi @doomspork,

So, we're having good-looking PRs hanging on merge queues because the CI does not run in merge queue's special branches. After a bit of exploration (and some help from DS4F), I found a fix.

See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## New Company Prerequisites

- [ ] ~Industry must be one of the 11 sectors of the [GICS](https://www.msci.com/our-solutions/indexes/gics).~
- [ ] ~The description makes some mention of Elixir usage.~
